### PR TITLE
bump Dockerfile base image to docker 24.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.11
+FROM docker:24.0.7
 
 RUN apk add --no-cache bash iproute2 iptables tzdata
 

--- a/test/containers/trafficjam_test/Dockerfile
+++ b/test/containers/trafficjam_test/Dockerfile
@@ -1,12 +1,9 @@
-FROM docker:20.10.11-dind
+FROM docker:24.0.7-dind
 
 ARG BATS_VER=v1.8.0
-ARG DOCKER_COMPOSE_VER=v2.0.1
 
 #Install Testing Dependencies
 RUN apk add --no-cache iptables git bash curl && \
-    curl -SL https://github.com/docker/compose/releases/download/v2.0.1/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose && \
-    chmod a+x /usr/local/bin/docker-compose && \
     git clone --depth 1 --branch $BATS_VER  https://github.com/bats-core/bats-core.git /opt/bats && \
     /opt/bats/install.sh /usr/local
 

--- a/test/test-dind.bats
+++ b/test/test-dind.bats
@@ -12,7 +12,7 @@ setup_file() {
 		fi
 		sleep 5
 	done
-	docker-compose -f /opt/trafficjam/test/docker-compose-dind.yml up -d
+	docker compose -f /opt/trafficjam/test/docker-compose-dind.yml up -d
 	docker exec traefik apk add --no-cache curl
 }
 
@@ -72,9 +72,9 @@ setup_file() {
 }
 
 @test "deploy with ALLOW_HOST_TRAFFIC" {
-	docker-compose -f /opt/trafficjam/test/docker-compose-dind.yml down
+	docker compose -f /opt/trafficjam/test/docker-compose-dind.yml down
 	sleep 5
-	docker-compose -f /opt/trafficjam/test/docker-compose-dind-allowhost.yml up -d
+	docker compose -f /opt/trafficjam/test/docker-compose-dind-allowhost.yml up -d
 }
 
 @test "containers can communicate via host-mapped ports (public1)" {


### PR DESCRIPTION
base image is outdated and probably vulnerable without security updates. tested a local build and it runs without issues so far.