### PR TITLE
Fix for Swarm mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.4.0
+        if: ${{ github.secret_source == 'Actions' }}
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/trafficjam.sh
+++ b/trafficjam.sh
@@ -21,6 +21,7 @@ fi
 : "${ALLOW_HOST_TRAFFIC:=}"
 : "${DEBUG:=}"
 : "${TZ:=}"
+: "${SWARM_WORKER:=}"
 NETNS=""
 OLD_SUBNET=""
 OLD_WHITELIST_IPS=""
@@ -75,6 +76,10 @@ else
 	while true; do
 		tj_sleep
 
+		if [[ -n "$SWARM_WORKER" ]]; then
+			log_debug "Running in swarm mode"
+		fi
+
 		get_network_driver || continue
 
 		get_network_subnet || continue
@@ -93,6 +98,11 @@ else
 			"$WHITELIST_IPS" != "$OLD_WHITELIST_IPS" ||
 			"$LOCAL_LOAD_BALANCER_IP" != "$OLD_LOCAL_LOAD_BALANCER_IP" ]] \
 			; then
+
+			if [[ -n "$SWARM_WORKER" && -z "$WHITELIST_IPS" && -z "$LOCAL_LOAD_BALANCER_IP" ]]; then
+				log_debug "No loadbalancer or container running on this node, skipping"
+				continue
+			fi
 
 			add_chain || continue
 


### PR DESCRIPTION
An attempt to fix the swarm mode. Can't test the impact for standard docker.

Ugly fix in `add_chain()` to get access to the new network namespace when no previous containers where running on the node on the targeted `$NETWORK`. Not sure if this is a kernel bug or an expected behaviour...
The error would be `nsenter: setns(): can't reassociate to namespace 'net': Invalid argument`

Fixes #18 