### PR TITLE
fix get_network_subnet when both ipv4 and ipv6 are defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ TrafficJam is configured via several environment variables:
   * **NOTE:** support for legacy iptables (non-nftables) is deprecated, not actively tested, and will be removed from a future release.
 * Modern version of Docker (trafficjam image and CI use 28.0.4)
 
+## Known Limitations
+* ipv6 is currently unsupported
+* networks with multiple IPAM configurations (e.g. ipv4 and ipv6 subnets) are not supported
+
 ## Clearing Rules
 `trafficjam` can be run with the `--clear` argument to remove all rules that have been set. Note that the host docker socket must be mounted within the container. The rules can also be cleared by sending the `SIGUSR1` signal to the container. This will cause `trafficjam` to exit.
 

--- a/trafficjam-functions.sh
+++ b/trafficjam-functions.sh
@@ -181,7 +181,7 @@ function get_network_driver() {
 }
 
 function get_network_subnet() {
-	if ! SUBNET=$(docker network inspect --format="{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}" "$NETWORK" 2>&1) || [[ -z "$SUBNET" ]]; then
+	if ! SUBNET=$(docker network inspect --format="{{ (index .IPAM.Config 0).Subnet }}" "$NETWORK" 2>&1) || [[ -z "$SUBNET" ]]; then
 		log_error "Unexpected error while determining network subnet: $SUBNET"
 		return 1
 	else


### PR DESCRIPTION
as reported in https://github.com/kaysond/trafficjam/issues/35, here is a small fix for configuration where "traefik" network is configured with ipv4 and ipv6
